### PR TITLE
Fix integer division on double

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -12,7 +12,7 @@ public final class Constants {
     public static final class SwerveModuleConstants {
         public static final double kWheelCircumference = Units.inchesToMeters(4) * Math.PI;
         public static final double kDriveMotorGearRatio = 6.67 / 1;
-        public static final double kSteerMotorGearRatio = 48 / 40;
+        public static final double kSteerMotorGearRatio = 48.0 / 40.0;
         public static final double kPTurning = 1.75;
         public static final double kITurning = 0;
         public static final double kDTurning = 0.0;
@@ -115,7 +115,7 @@ public final class Constants {
          * 16 tooth gear that drives a 58 tooth gear that is coaxial with a 12 tooth
          * gear that drives a 30 tooth gear via chain. :')
          */
-        public static final double kFlipGearRatio = (12 / 60) * (16 / 58) * (12 / 30);
+        public static final double kFlipGearRatio = (12.0 / 60.0) * (16.0 / 58.0) * (12.0 / 30.0);
 
         public static final int flipPulsesPerRevolution = kCimcoder256PulsesPerRevolution;
         public static final double flipRotationsToRadians = 2 * Math.PI / kFlipGearRatio;
@@ -168,7 +168,7 @@ public final class Constants {
         public static final int verticalMotorAPort = 0;
         public static final int verticalMotorBPort = 0;
 
-        public static final double verticalGearRatio = 12 / 60;
+        public static final double verticalGearRatio = 12.0 / 60.0;
         public static final double verticalMaxLength = Units.inchesToMeters(30);
         public static final double verticalGearDiameter = Units.inchesToMeters(1.76);
 
@@ -185,7 +185,7 @@ public final class Constants {
         public static final int horizonalEncoderPortA = 0;
         public static final int horizonalEncoderPortB = 0;
 
-        public static final double horizontalGearRatio = 12 / 60;
+        public static final double horizontalGearRatio = 12.0 / 60.0;
         public static final double horizontalMaxExtensionLength = Units.inchesToMeters(15);
         public static final double horizontalGearDiameter = Units.inchesToMeters(1.76);
 


### PR DESCRIPTION
Doing an integer division with constants when initializing a double will first perform the integer division and then autobox to a double, this is not our desired behavior.